### PR TITLE
Implemented new sign in with google authentication API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ dmypy.json
 .idea
 *.pyc
 dev.env
+.vscode/settings.json

--- a/CDC_Backend/APIs/constants.py
+++ b/CDC_Backend/APIs/constants.py
@@ -49,6 +49,9 @@ CDC_MAIl_ADDRESS = 'cdc@iitdh.ac.in'
 
 # To be Configured Properly
 CLIENT_ID = os.environ.get('GOOGLE_OAUTH_CLIENT_ID')  # Google Login Client ID
+CLIENT_SECRET = os.environ.get('GOOGLE_OAUTH_CLIENT_SECRET')  # Google Login Client Secret
+REDIRECT_URI = 'postmessage'  # Google Login Redirect URI
+OAUTH2_API_ENDPOINT = 'https://oauth2.googleapis.com/token'  # Google Login OAUTH2 URL
 
 # To be Configured Properly
 PLACEMENT_OPENING_URL = "https://cdc.iitdh.ac.in/portal/student/dashboard/placements/{id}"  # On frontend, this is the URL to be opened
@@ -58,6 +61,9 @@ LINK_TO_APPLICATIONS_CSV = "https://cdc.iitdh.ac.in/storage/Application_CSV/"
 LINK_TO_EMAIl_VERIFICATION_API = "https://cdc.iitdh.ac.in/portal/company/verifyEmail?token={token}"
 PDF_FILES_SERVING_ENDPOINT = 'https://cdc.iitdh.ac.in/storage/Company_Attachments/'  # TODO: Change this to actual URL
 
+AUTH_CODE = "code"
+ID_TOKEN = "id_token"
+REFRESH_TOKEN = "refresh_token"
 EMAIL = "email"
 
 STUDENT = 'student'

--- a/CDC_Backend/APIs/urls.py
+++ b/CDC_Backend/APIs/urls.py
@@ -4,6 +4,7 @@ from . import studentViews, studentUrls, companyUrls, adminUrls
 
 urlpatterns = [
     path('login/', studentViews.login, name="Login"),
+    path('refresh_token/', studentViews.refresh, name="Refresh Token"),
     path('student/', include(studentUrls)),
     path('company/', include(companyUrls)),
     path('admin/', include(adminUrls)),

--- a/CDC_Backend/APIs/utils.py
+++ b/CDC_Backend/APIs/utils.py
@@ -33,6 +33,38 @@ from .models import User, PrePlacementOffer, PlacementApplication, Placement, St
 logger = logging.getLogger('db')
 
 
+def get_token():
+    def decorator(view_func):
+        def wrapper_func(request, *args, **kwargs):
+            try:
+                authcode = request.data[AUTH_CODE]
+                data = {
+                    'code': authcode,
+                    'client_id': CLIENT_ID,
+                    'client_secret': CLIENT_SECRET,
+                    'redirect_uri': REDIRECT_URI,
+                    'grant_type': 'authorization_code'
+                }
+                r = rq.post(OAUTH2_API_ENDPOINT, data=data)
+                if r.status_code == 200:
+                    response = r.json()
+                    token = response[ID_TOKEN]
+                    refresh_token = response[REFRESH_TOKEN]
+                    request.META["HTTP_AUTHORIZATION"] = "Bearer " + token
+                    request.META["MODIFIED"] = "True"
+                    kwargs['refresh_token'] = refresh_token
+                    return view_func(request, *args, **kwargs)
+                else:
+                    return Response({'action': "Get Token", 'message': "Invalid Auth Code"},
+                                    status=status.HTTP_400_BAD_REQUEST)
+            except Exception as e:
+                logger.warning("Get Token: " + str(sys.exc_info()))
+                return Response({'action': "Get Token", 'message': str(e)},
+                                status=status.HTTP_400_BAD_REQUEST)
+        return wrapper_func
+    return decorator
+
+
 def precheck(required_data=None):
     if required_data is None:
         required_data = []
@@ -84,7 +116,10 @@ def isAuthorized(allowed_users=None):
                         user.last_login_time = timezone.now()
                         user.save()
                         if len(set(user.user_type).intersection(set(allowed_users))) or allowed_users == '*':
-                            return view_func(request, user.id, user.email, user.user_type, *args, **kwargs)
+                            if "MODIFIED" in headers:
+                                return view_func(request, user.id, user.email, user.user_type, token_id, *args, **kwargs)
+                            else:
+                                return view_func(request, user.id, user.email, user.user_type, *args, **kwargs)
                         else:
                             raise PermissionError("Access Denied. You are not allowed to use this service")
                 else:


### PR DESCRIPTION
This new API require the oauth client secret also including client id hence a new env variable `GOOGLE_OAUTH_CLIENT_SECRET` should to present with value of the client secret.

Gets authentication code from frontend and using the google token api it gets the `id_token` and `refresh_token`. Sends back `id_token` and `refresh_token` to frontend.

When id_token is expired it needs to be refreshed using `refresh_token` for which a new endpoint `/api/refesh_token` is added.

`id_token` is verified and used same as in previous API.